### PR TITLE
Fixed apply and division-specific pages

### DIFF
--- a/config/apply.config.ts
+++ b/config/apply.config.ts
@@ -1,30 +1,35 @@
-import { ApplyPageData } from "../lib/types";
+import { ApplyPageData } from '../lib/types';
 
 export const applyPageData: ApplyPageData = {
   programs: [
     {
+      programName: 'ACM Projects',
       division: 'projects',
       program: 'projects',
       programImage: 'projects',
-      link: 'https://portal.acmutd.co/applications',
+      link: '/projects',
     },
     {
+      programName: 'Technical Interview Prep',
       division: 'education',
       program: 'tip',
       programImage: 'tip',
-      link: '/',
+      link: '/education/tip',
     },
     {
+      programName: 'ACM Research',
       division: 'research',
       program: 'research',
       programImage: 'research',
-      link: '/',
+      link: '/research',
     },
     {
-      division: 'research',
+      programName: 'Mentor Program',
+      division: 'education',
       program: 'mentor',
       programImage: 'mentor',
-      link: '/',
+      link: '/education/mentor',
     },
   ],
 };
+

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -21,6 +21,7 @@ export type AboutPageData = {
 
 // Apply page types
 export type ProgramInfo = {
+  programName: string;
   division: string;
   program: string;
   programImage: string;

--- a/src/app/education/mentor/page.tsx
+++ b/src/app/education/mentor/page.tsx
@@ -4,6 +4,7 @@ import Navigator from '@/components/Divisions/Shared/Navigator';
 import DivisionExperience from '@/components/Divisions/Shared/DivisionExperience';
 import DivisionFAQ from '@/components/Divisions/Shared/DivisionFAQ';
 import WorkShops from '@/components/Divisions/Shared/WorkShops';
+import { MentorHeader } from '@/components/Divisions/Mentor/MentorHeader';
 
 export default function Page() {
   return (
@@ -11,6 +12,7 @@ export default function Page() {
       <Navigator division="education" sub="mentor" />
       <DivisionCarousel division="education" sub="mentor" />
       <div className="pl-28">
+        <MentorHeader />
         <DivisionOfficers division="education" />
         <DivisionExperience division="education" sub="mentor" />
         <WorkShops sub="mentor" />

--- a/src/app/education/tip/page.tsx
+++ b/src/app/education/tip/page.tsx
@@ -4,6 +4,7 @@ import Navigator from '@/components/Divisions/Shared/Navigator';
 import DivisionExperience from '@/components/Divisions/Shared/DivisionExperience';
 import DivisionFAQ from '@/components/Divisions/Shared/DivisionFAQ';
 import WorkShops from '@/components/Divisions/Shared/WorkShops';
+import { TIPHeader } from '@/components/Divisions/TIP/TIPHeader';
 
 export default function Page() {
   return (
@@ -11,6 +12,7 @@ export default function Page() {
       <Navigator division="education" sub="tip" />
       <DivisionCarousel division="education" sub="tip" />
       <div className="pl-28">
+        <TIPHeader />
         <DivisionOfficers division="education" />
         <DivisionExperience division="education" sub="tip" />
         <WorkShops sub="tip" />

--- a/src/components/Apply/ApplyHeader.tsx
+++ b/src/components/Apply/ApplyHeader.tsx
@@ -14,7 +14,7 @@ function ApplyHeader() {
               <br />
               <br />
               All open applications can be found in our member portal at
-              portal.acmutd.co/applications
+              portal.acmutd.co/opportunities
             </p>
           </div>
           <Image

--- a/src/components/Apply/ApplyProgramCard.tsx
+++ b/src/components/Apply/ApplyProgramCard.tsx
@@ -11,7 +11,7 @@ interface ApplyProgramCardProps {
 function ApplyProgramCard({ title, image, link }: ApplyProgramCardProps) {
   return (
     <Link href={link} className="relative flex w-full items-center justify-center">
-      <h1 className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 transform text-4xl font-bold text-primary xl:text-5xl">
+      <h1 className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 transform text-center text-4xl font-bold text-primary xl:text-5xl">
         {title}
       </h1>
       <Image src={image} alt={title} width={500} height={500} className="w-full" />

--- a/src/components/Apply/ApplyPrograms.tsx
+++ b/src/components/Apply/ApplyPrograms.tsx
@@ -14,7 +14,7 @@ function ApplyPrograms() {
       </p>
       <div className="flex w-full justify-end pr-10">
         <Link
-          href="https://portal.acmutd.co"
+          href="https://portal.acmutd.co/opportunities"
           className="mt-6 flex h-12 w-64 items-center justify-center bg-acm-gradient py-2 text-2xl font-bold text-primary md:text-3xl"
         >
           apply now
@@ -22,12 +22,14 @@ function ApplyPrograms() {
       </div>
       <div className="mt-10 grid md:grid-cols-2">
         {applyPageData.programs.map((data: ProgramInfo, index: number) => {
-           return <ApplyProgramCard
-             title="ACM Projects"
-             image={`/assets/apply/programs/${data.programImage}.png`}
-             link={data.link}
-             key={index}
-           />;
+          return (
+            <ApplyProgramCard
+              title={data.programName}
+              image={`/assets/apply/programs/${data.programImage}.png`}
+              link={data.link}
+              key={index}
+            />
+          );
         })}
       </div>
     </div>

--- a/src/components/Divisions/Mentor/MentorHeader.tsx
+++ b/src/components/Divisions/Mentor/MentorHeader.tsx
@@ -1,0 +1,10 @@
+import DivisionHeader from '@/components/Divisions/Shared/DivisionHeader';
+
+export function MentorHeader() {
+  return (
+    <DivisionHeader division="education.mentor">
+      Get a chance to network, access resources like Udemy courses, and attend exclusive socials and
+      workshops! Apply to be a Mentor or a Mentee today!
+    </DivisionHeader>
+  );
+}

--- a/src/components/Divisions/Shared/DivisionHeader.tsx
+++ b/src/components/Divisions/Shared/DivisionHeader.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
 import { ExtendedDivisions } from './divisionUtil';
 import Image from 'next/image';
+import Link from 'next/link';
 
 type DivisionHeaderProps = {
   children: ReactNode;
@@ -11,12 +12,43 @@ export default function DivisionHeader({ children, division }: DivisionHeaderPro
     <div className="pt-40 font-sans">
       {images[division]}
       <p className="w-[55rem] pt-5 text-2xl text-[#CACACA]">{children}</p>
-      <button className={`mt-20 bg-${division}-gradient px-5 py-2 text-xl text-white`}>
-        apply today
-      </button>
+      {typeof applicationUrl[division] === 'string' ? (
+        <div className="mt-20 flex items-center">
+          <Link href={applicationUrl[division]}>
+            <div className={`bg-${division.split('.')[0]}-gradient px-5 py-2 text-xl text-white`}>
+              apply today
+            </div>
+          </Link>
+        </div>
+      ) : (
+        <div className="mt-20 flex items-center gap-x-3">
+          {Object.entries(applicationUrl[division] as Record<string, string>).map(
+            ([roleName, appUrl]) => (
+              <Link href={appUrl} key={roleName}>
+                <div
+                  className={`bg-${division.split('.')[0]}-gradient px-5 py-2 text-xl text-white`}
+                >
+                  apply today as {roleName}
+                </div>
+              </Link>
+            ),
+          )}
+        </div>
+      )}
     </div>
   );
 }
+
+// NOTE: This will need to be changed every semester until we have a database
+const applicationUrl: Record<ExtendedDivisions, string | Record<string, string>> = {
+  'education.mentor': {
+    Mentor: 'https://portal.acmutd.co/typeform/mentor-app-f24',
+    Mentee: 'https://portal.acmutd.co/typeform/mentee-app-f24',
+  },
+  'education.tip': 'https://portal.acmutd.co/typeform/tip-app-f24',
+  projects: 'https://portal.acmutd.co/typeform/projects-apply-f24',
+  research: 'https://portal.acmutd.co/typeform/research-apply-f24',
+};
 
 const images: Record<ExtendedDivisions, ReactNode> = {
   projects: (

--- a/src/components/Divisions/TIP/TIPHeader.tsx
+++ b/src/components/Divisions/TIP/TIPHeader.tsx
@@ -1,0 +1,11 @@
+import DivisionHeader from '../Shared/DivisionHeader';
+
+export function TIPHeader() {
+  return (
+    <DivisionHeader division="education.tip">
+      Trying to land an internship? TIP is a 10-week-long program, focused on preparing you for
+      technical and behavioral interviews. The program will help build your intuition and practice
+      foundational data structures and algorithms present in most technical interviews.
+    </DivisionHeader>
+  );
+}


### PR DESCRIPTION
Changes made in this PR: 
- `/apply`: division cards goes to detailed divisions pages
- `/[division]`: apply button goes to portal application page