### PR TITLE
fix: Update revalidation and caching when fetching upcoming events

### DIFF
--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,5 +1,8 @@
 import type { Event } from '@/../lib/types.d.ts';
 import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
 const calendarId =
   'c_893d7ec01b0d651ddfadf46f6792b1d470abe97c6d9f33157a1f4be2d4420a51@group.calendar.google.com';
 const endpoint = `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events`;
@@ -18,6 +21,7 @@ export async function GET() {
   });
 
   const now = new Date();
+  now.setHours(0, 0, 0, 0);
   const upcoming = events.filter((event) => event.start && event.start > now);
 
   return new NextResponse<Event[]>(JSON.stringify(upcoming));

--- a/src/components/Events/UpcomingEvents.tsx
+++ b/src/components/Events/UpcomingEvents.tsx
@@ -1,5 +1,7 @@
 import type { Event } from '@/../lib/types';
-import { GET as getUpcoming } from '@/app/api/events/route';
+
+const BASE_API_URL =
+  process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : 'https://acmutd.co';
 
 const colors = [
   { from: 'from-[#008CF1]', to: 'to-[#00ECEC]' },
@@ -8,7 +10,9 @@ const colors = [
 ];
 
 export default async function UpcomingEvents() {
-  const res = await getUpcoming().then((res) => res.json());
+  const res = await fetch(BASE_API_URL + '/api/events', { next: { revalidate: 60 } }).then((res) =>
+    res.json(),
+  );
   const events: Event[] = res.map((item: any) => {
     const event: Event = {
       id: item.id,


### PR DESCRIPTION
Upcoming events weren't showing up due to static get function