### PR TITLE
fix/make calendar events load on client to get correct timezone and date

### DIFF
--- a/src/components/Events/CalendarBody.tsx
+++ b/src/components/Events/CalendarBody.tsx
@@ -1,4 +1,6 @@
+import EventComponent from './EventDays';
 import type { Event } from '@/../lib/types.d.ts';
+
 const daysOfWeek = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
 type Props = {
@@ -37,18 +39,9 @@ export default function CalendarBody({ year, month, events }: Props) {
         >
           <p className="absolute right-2 top-2 text-xs font-bold md:text-sm">{day}</p>
           <div className="mt-4">
-            {events.map((event) => {
-              if (!event.start || event.start.getDate() !== day || event.start.getMonth() !== month)
-                return;
-              return (
-                <div
-                  key={event.id}
-                  className="mt-2 truncate rounded bg-green-200 p-1 text-xs font-medium text-green-800"
-                >
-                  {event.title}
-                </div>
-              );
-            })}
+            {events.map((event) => (
+              <EventComponent key={event.id} event={event} day={day} month={month} />
+            ))}
           </div>
         </div>
       ))}

--- a/src/components/Events/EventDays.tsx
+++ b/src/components/Events/EventDays.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { Event } from '@/../lib/types.d.ts';
+
+type Props = {
+  event: Event;
+  day: number;
+  month: number;
+};
+
+const EventComponent = ({ event, day, month }: Props) => {
+  const [localStartDate, setLocalStartDate] = useState<Date | null>(null);
+
+  useEffect(() => {
+    if (event.start) {
+      const localDate = new Date(event.start);
+      setLocalStartDate(localDate);
+    }
+  }, [event]);
+
+  if (!localStartDate || localStartDate.getDate() !== day || localStartDate.getMonth() !== month) {
+    return null;
+  }
+
+  return (
+    <div className="mt-2 truncate rounded bg-green-200 p-1 text-xs font-medium text-green-800">
+      {event.title}
+    </div>
+  );
+};
+
+export default EventComponent;


### PR DESCRIPTION
Events showing up on wrong day in production
<img width="1398" alt="image" src="https://github.com/user-attachments/assets/2a326a75-67a8-4739-9e27-769b0c94913c">
(projects presentation night was on the 21st rather than 20th)
This fixes to load those events on the client
