### PR TITLE
fix(*) un-bugged links

### DIFF
--- a/config/about.config.ts
+++ b/config/about.config.ts
@@ -11,9 +11,9 @@ export const aboutPageData: AboutPageData = {
       description:
         'ACM Development designs, builds, and maintains web applications that support ACM’s operations and member interactions. Projects like the Member Portal and UTD Grades ensure reliable and user-friendly platforms for the campus community.',
       links: [
-        { name: 'acm portal', link: 'https://github.com/acmutd/portal-next' },
-        { name: 'utdgrades', link: 'https://github.com/acmutd/utd-grades' },
-        { name: 'github', link: 'https://github.com/acmutd' },
+        { name: 'acm portal', link: 'github.com/acmutd/portal-next' },
+        { name: 'utdgrades', link: 'github.com/acmutd/utd-grades' },
+        { name: 'github', link: 'github.com/acmutd' },
       ],
       linkStyles: '',
     },
@@ -48,7 +48,7 @@ export const aboutPageData: AboutPageData = {
         { name: 'youtube', link: 'www.youtube.com/@acmutdallas4256' },
         {
           name: 'newsletter',
-          link: 'https://cdn.forms-content.sg-form.com/22d851f4-5f47-11eb-9b58-e2c4feadfaf0',
+          link: 'cdn.forms-content.sg-form.com/22d851f4-5f47-11eb-9b58-e2c4feadfaf0',
         },
       ],
     },


### PR DESCRIPTION

https://github.com/user-attachments/assets/0c4808d3-9b03-450c-9dc6-b7acbd53fe5c

I was scrolling the ACM website and found that the links for the newsletter in ACM media, and all of the ACM development links are broken. The ACM portal button redirects to: https://https//github.com/acmutd/portal-next 

There is a clip linked above showing this issue.