### PR TITLE
fix: correct calendar for fall events

### DIFF
--- a/src/app/api/events/past/route.ts
+++ b/src/app/api/events/past/route.ts
@@ -3,8 +3,7 @@ import { NextResponse } from 'next/server';
 
 export const dynamic = 'force-dynamic';
 
-const calendarId =
-  'c_893d7ec01b0d651ddfadf46f6792b1d470abe97c6d9f33157a1f4be2d4420a51@group.calendar.google.com';
+const calendarId = process.env.CALENDAR_ID;
 const endpoint = `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events`;
 
 type CalendarApiResponse = {
@@ -30,6 +29,12 @@ export async function GET() {
     if (!process.env.CALENDAR_API_KEY) {
       return NextResponse.json(
         { error: 'Calendar API key is not configured' },
+        { status: 500 }
+      );
+    }
+    else if (!process.env.CALENDAR_ID) {
+      return NextResponse.json(
+        { error: 'Calendar ID is not configured' },
         { status: 500 }
       );
     }

--- a/src/app/api/events/past/route.ts
+++ b/src/app/api/events/past/route.ts
@@ -4,7 +4,7 @@ import { NextResponse } from 'next/server';
 export const dynamic = 'force-dynamic';
 
 const calendarId =
-  'c_893d7ec01b0d651ddfadf46f6792b1d470abe97c6d9f33157a1f4be2d4420a51@group.calendar.google.com';
+  'c_3a5b5311f40423092c66bb75ea43060109e03f61514557d285298c0495d1681b@group.calendar.google.com';
 const endpoint = `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events`;
 
 type CalendarApiResponse = {

--- a/src/app/api/events/past/route.ts
+++ b/src/app/api/events/past/route.ts
@@ -4,7 +4,7 @@ import { NextResponse } from 'next/server';
 export const dynamic = 'force-dynamic';
 
 const calendarId =
-  'c_3a5b5311f40423092c66bb75ea43060109e03f61514557d285298c0495d1681b@group.calendar.google.com';
+  'c_893d7ec01b0d651ddfadf46f6792b1d470abe97c6d9f33157a1f4be2d4420a51@group.calendar.google.com';
 const endpoint = `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events`;
 
 type CalendarApiResponse = {

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -3,8 +3,7 @@ import { NextResponse } from 'next/server';
 
 export const dynamic = 'force-dynamic';
 
-const calendarId =
-  'c_3a5b5311f40423092c66bb75ea43060109e03f61514557d285298c0495d1681b@group.calendar.google.com';
+const calendarId = process.env.CALENDAR_ID;
 const endpoint = `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events`;
 const calendarTimeZone = 'America/Chicago';
 
@@ -31,6 +30,12 @@ export async function GET(request: Request) {
     if (!process.env.CALENDAR_API_KEY) {
       return NextResponse.json(
         { error: 'Calendar API key is not configured' },
+        { status: 500 }
+      );
+    }
+    else if (!process.env.CALENDAR_ID) {
+      return NextResponse.json(
+        { error: 'Calendar ID is not configured' },
         { status: 500 }
       );
     }

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -4,7 +4,7 @@ import { NextResponse } from 'next/server';
 export const dynamic = 'force-dynamic';
 
 const calendarId =
-  'c_893d7ec01b0d651ddfadf46f6792b1d470abe97c6d9f33157a1f4be2d4420a51@group.calendar.google.com';
+  'c_3a5b5311f40423092c66bb75ea43060109e03f61514557d285298c0495d1681b@group.calendar.google.com';
 const endpoint = `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events`;
 const calendarTimeZone = 'America/Chicago';
 


### PR DESCRIPTION
A potential solution for getting auto-populated events on the website, however it achieves this by routing to the internal calendar which includes events not open to the public. Need to talk to Exec about getting a dedicated events calendar and/or if the calendar i replaced here is that calendar, in which case the board needs access to it to get events. 

Don't merge for now, i had to temporarily enable public access to the internal calendar just to see if this would work but i turned it off because it's not the solution we should use imo. Will get back to this before the semester starts