### PR TITLE
style: Changes for Division Carousels

### DIFF
--- a/src/components/Divisions/Shared/DivisionsCarousel.tsx
+++ b/src/components/Divisions/Shared/DivisionsCarousel.tsx
@@ -14,6 +14,8 @@ import {
 import { useEffect, useState } from 'react';
 
 export default function DivisionsCarousel(props: DivisionProps) {
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+  const [showModal, setShowModal] = useState(false);
   const images = getCarouselImages(props);
   const [current, setCurrent] = useState(0);
   const [api, setApi] = useState<CarouselApi>();
@@ -30,56 +32,111 @@ export default function DivisionsCarousel(props: DivisionProps) {
 
   const division = props.division || 'education'; // TIP and Mentor will default to Education division that way
 
-  return (
-    <div className={`w-full max-w-4xl mx-auto rounded-lg overflow-hidden shadow-lg p-[2px] bg-${division}-gradient`}>
-      <div className="relative aspect-video w-full overflow-hidden group bg-black rounded-lg">
-        <Carousel
-          className="w-full h-full"
-          opts={{
-            loop: true,
-            align: "center",
-          }}
-          setApi={setApi}
-        >
-          <CarouselContent>
-            {images.map((image, i) => (
-              <CarouselItem key={i}>
-                <div className="relative w-full h-full flex items-center justify-center aspect-video">
-                  <Image
-                    src={image.imageLink}
-                    alt={image.title}
-                    className="h-full w-full object-cover rounded-lg"
-                    fill
-                    priority={i === 0}
-                  />
-                  {/* Description box at bottom right */}
-                  {i === current && (
-                    <div className="absolute bottom-4 right-4 bg-black/60 rounded-md px-4 py-2 text-white text-sm md:text-base font-medium shadow-lg">
-                      {image.title}
-                    </div>
-                  )}
-                </div>
-              </CarouselItem>
-            ))}
-          </CarouselContent>
-          <CarouselPrevious className="absolute left-1 sm:left-2 top-1/2 -translate-y-1/2 bg-black/40 p-1.5 sm:p-2 rounded-full text-white opacity-100 sm:opacity-0 group-hover:opacity-100 transition-opacity duration-300 border-none hover:bg-black/60" />
-          <CarouselNext className="absolute right-1 sm:right-2 top-1/2 -translate-y-1/2 bg-black/40 p-1.5 sm:p-2 rounded-full text-white opacity-100 sm:opacity-0 group-hover:opacity-100 transition-opacity duration-300 border-none hover:bg-black/60" />
-        </Carousel>
+  // Fade in/out logic
+  useEffect(() => {
+    if (lightboxOpen) {
+      setShowModal(true);
+    } else {
+      const timeout = setTimeout(() => setShowModal(false), 300);
+      return () => clearTimeout(timeout);
+    }
+  }, [lightboxOpen]);
 
-        <div className="absolute bottom-2 sm:bottom-4 left-1/2 -translate-x-1/2 flex space-x-1.5 sm:space-x-2 z-10">
-          {images.map((_, i) => (
-            <button
-              key={i}
-              className={`h-2 sm:h-2.5 md:h-3 w-2 sm:w-2.5 md:w-3 rounded-full transition-all duration-300 ${i === current
-                  ? 'scale-110 bg-white shadow-md'
-                  : 'bg-white/50 hover:bg-white/80'
-                }`}
-              aria-label={`Go to slide ${i + 1}`}
-              onClick={() => api?.scrollTo(i)}
-            />
-          ))}
+  return (
+    <>
+      <div className={`w-full max-w-4xl mx-auto rounded-lg overflow-hidden shadow-lg p-[2px] bg-${division}-gradient`}>
+        <div className="relative aspect-video w-full overflow-hidden group bg-black rounded-lg">
+          <Carousel
+            className="w-full h-full"
+            opts={{
+              loop: true,
+              align: "center",
+            }}
+            setApi={setApi}
+          >
+            <CarouselContent>
+              {images.map((image, i) => (
+                <CarouselItem key={i}>
+                  <div className="relative w-full h-full flex items-center justify-center aspect-video">
+                    <button
+                      type="button"
+                      className="w-full h-full focus:outline-none"
+                      onClick={() => { setCurrent(i); setLightboxOpen(true); }}
+                      aria-label={`View ${image.title} in full view`}
+                    >
+                      <Image
+                        src={image.imageLink}
+                        alt={image.title}
+                        className="h-full w-full object-cover rounded-lg hover:brightness-90 transition-all"
+                        fill
+                        priority={i === 0}
+                      />
+                    </button>
+                    {/* Description box at bottom right */}
+                    {i === current && (
+                      <div className="absolute bottom-4 right-4 bg-black/60 rounded-md px-4 py-2 text-white text-sm md:text-base font-medium shadow-lg">
+                        {image.title}
+                      </div>
+                    )}
+                  </div>
+                </CarouselItem>
+              ))}
+            </CarouselContent>
+            <CarouselPrevious className="absolute left-1 sm:left-2 top-1/2 -translate-y-1/2 bg-black/40 p-1.5 sm:p-2 rounded-full text-white opacity-100 sm:opacity-0 group-hover:opacity-100 transition-opacity duration-300 border-none hover:bg-black/60" />
+            <CarouselNext className="absolute right-1 sm:right-2 top-1/2 -translate-y-1/2 bg-black/40 p-1.5 sm:p-2 rounded-full text-white opacity-100 sm:opacity-0 group-hover:opacity-100 transition-opacity duration-300 border-none hover:bg-black/60" />
+          </Carousel>
+          <div className="absolute bottom-2 sm:bottom-4 left-1/2 -translate-x-1/2 flex space-x-1.5 sm:space-x-2 z-10">
+            {images.map((_, i) => (
+              <button
+                key={i}
+                className={`h-2 sm:h-2.5 md:h-3 w-2 sm:w-2.5 md:w-3 rounded-full transition-all duration-300 ${i === current
+                    ? 'scale-110 bg-white shadow-md'
+                    : 'bg-white/50 hover:bg-white/80'
+                  }`}
+                aria-label={`Go to slide ${i + 1}`}
+                onClick={() => api?.scrollTo(i)}
+              />
+            ))}
+          </div>
         </div>
       </div>
-    </div>
+
+      {/* Lightbox modal */}
+      {/* The images will be displayed in their full size in the modal */}
+      <div
+        className={`fixed inset-0 z-[100] flex items-center justify-center bg-black/80 transition-opacity duration-300 ${showModal ? (lightboxOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none') : 'opacity-0 pointer-events-none'}`}
+        onClick={() => setLightboxOpen(false)}
+        aria-hidden={!lightboxOpen}
+      >
+        <div
+          className={`relative flex items-center justify-center rounded-lg p-[2px] bg-gradient-to-r bg-${division}-gradient`}
+          onClick={e => e.stopPropagation()}
+        >
+          <div className="relative rounded-lg overflow-hidden">
+            <Image
+              src={images[current].imageLink}
+              alt={images[current].title}
+              className="rounded-lg"
+              priority
+              sizes="100vw"
+              width={1200}
+              height={800}
+              style={{ height: 'auto', width: 'auto', maxHeight: '80vh', maxWidth: '90vw' }}
+            />
+            <div className="absolute bottom-4 right-4 bg-black/60 rounded-md px-4 py-2 text-white text-sm md:text-base font-medium shadow-lg">
+              {images[current].title}
+            </div>
+          </div>
+          <button
+            type="button"
+            className="absolute top-4 right-4 text-white bg-black/60 rounded-full p-2 hover:bg-black/80 focus:outline-none"
+            onClick={() => setLightboxOpen(false)}
+            aria-label="Close full view"
+          >
+            &#10005;
+          </button>
+        </div>
+      </div>
+    </>
   );
 }

--- a/src/components/Divisions/Shared/DivisionsCarousel.tsx
+++ b/src/components/Divisions/Shared/DivisionsCarousel.tsx
@@ -54,7 +54,7 @@ export default function DivisionsCarousel(props: DivisionProps) {
 
   return (
     <>
-      <div className={`w-full max-w-4xl mx-auto rounded-lg overflow-hidden shadow-lg p-[2px] bg-${division}-gradient`}>
+  <div className={`w-full sm:max-w-4xl max-w-[calc(100vw-1rem)] rounded-lg overflow-hidden shadow-lg p-[2px] bg-${division}-gradient mx-auto`}>
         <div className="relative aspect-video w-full overflow-hidden group bg-black rounded-lg">
           <Carousel
             className="w-full h-full"

--- a/src/components/Divisions/Shared/DivisionsCarousel.tsx
+++ b/src/components/Divisions/Shared/DivisionsCarousel.tsx
@@ -28,13 +28,13 @@ export default function DivisionsCarousel(props: DivisionProps) {
     });
   }, [api]);
 
+  const division = props.division || 'education'; // TIP and Mentor will default to Education division that way
+
   return (
-    <div className="w-full max-w-4xl mx-auto rounded-lg overflow-hidden shadow-lg">
-      <div
-        className="relative h-56 sm:h-64 md:h-96 w-full overflow-hidden group"
-      >
+    <div className={`w-full max-w-4xl mx-auto rounded-lg overflow-hidden shadow-lg p-[2px] bg-${division}-gradient`}>
+      <div className="relative aspect-video w-full overflow-hidden group bg-black rounded-lg">
         <Carousel
-          className={`w-full h-full bg-${props.division}-gradient`}
+          className="w-full h-full"
           opts={{
             loop: true,
             align: "center",
@@ -44,14 +44,20 @@ export default function DivisionsCarousel(props: DivisionProps) {
           <CarouselContent>
             {images.map((image, i) => (
               <CarouselItem key={i}>
-                <div className="relative h-56 sm:h-64 md:h-96 w-full flex items-center justify-center p-2 sm:p-3 md:p-4">
+                <div className="relative w-full h-full flex items-center justify-center aspect-video">
                   <Image
                     src={image.imageLink}
                     alt={image.title}
-                    className="h-full w-full object-contain"
+                    className="h-full w-full object-cover rounded-lg"
                     fill
                     priority={i === 0}
                   />
+                  {/* Description box at bottom right */}
+                  {i === current && (
+                    <div className="absolute bottom-4 right-4 bg-black/60 rounded-md px-4 py-2 text-white text-sm md:text-base font-medium shadow-lg">
+                      {image.title}
+                    </div>
+                  )}
                 </div>
               </CarouselItem>
             ))}
@@ -64,40 +70,15 @@ export default function DivisionsCarousel(props: DivisionProps) {
           {images.map((_, i) => (
             <button
               key={i}
-              className={`h-2 sm:h-2.5 md:h-3 w-2 sm:w-2.5 md:w-3 rounded-full transition-all duration-300 ${
-                i === current
+              className={`h-2 sm:h-2.5 md:h-3 w-2 sm:w-2.5 md:w-3 rounded-full transition-all duration-300 ${i === current
                   ? 'scale-110 bg-white shadow-md'
                   : 'bg-white/50 hover:bg-white/80'
-              }`}
+                }`}
               aria-label={`Go to slide ${i + 1}`}
               onClick={() => api?.scrollTo(i)}
             />
           ))}
         </div>
-      </div>
-
-      <div
-        className={`flex flex-col sm:flex-row w-full justify-between bg-${props.division}-gradient p-3 sm:p-4 md:p-5 text-white`}
-      >
-        <p className="font-semibold text-center sm:text-left text-sm sm:text-base md:text-lg">{images[current].title}</p>
-        <p className="text-xs sm:text-sm text-center sm:text-right mt-1 sm:mt-0 opacity-90">
-          Shot{' '}
-          {images[current].date.toLocaleDateString('en-US', {
-            weekday: 'long',
-            month: 'long',
-            day: 'numeric',
-          })}
-          {images[current].date.getHours() !== 0 || images[current].date.getMinutes() !== 0 ? (
-            <>
-              {' at '}
-              {images[current].date.toLocaleTimeString('en-US', {
-                hour: 'numeric',
-                minute: images[current].date.getMinutes() > 0 ? 'numeric' : undefined,
-                timeZoneName: 'short',
-              })}
-            </>
-          ) : null}
-        </p>
       </div>
     </div>
   );

--- a/src/components/Divisions/Shared/DivisionsCarousel.tsx
+++ b/src/components/Divisions/Shared/DivisionsCarousel.tsx
@@ -119,7 +119,7 @@ export default function DivisionsCarousel(props: DivisionProps) {
         aria-hidden={!lightboxOpen}
       >
         <div
-          className={`relative flex items-center justify-center rounded-lg p-[2px] bg-gradient-to-r bg-${division}-gradient`}
+          className={`relative flex items-center justify-center rounded-lg p-[2px] bg-${division}-gradient`}
           onClick={e => e.stopPropagation()}
         >
           <div className="relative rounded-lg overflow-hidden">

--- a/src/components/Divisions/Shared/DivisionsCarousel.tsx
+++ b/src/components/Divisions/Shared/DivisionsCarousel.tsx
@@ -20,6 +20,16 @@ export default function DivisionsCarousel(props: DivisionProps) {
   const [current, setCurrent] = useState(0);
   const [api, setApi] = useState<CarouselApi>();
 
+  // Carousel autoscroller (every 5s)
+  // Will stop when lightbox modal is open
+  useEffect(() => {
+    if (!api || images.length <= 1 || lightboxOpen) return;
+    const interval = setInterval(() => {
+      api.scrollTo((api.selectedScrollSnap() + 1) % images.length);
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [api, images.length, lightboxOpen]);
+
   useEffect(() => {
     if (!api) return;
 

--- a/src/components/Divisions/Shared/Navigator.tsx
+++ b/src/components/Divisions/Shared/Navigator.tsx
@@ -33,7 +33,7 @@ export default function Navigator(props: DivisionProps) {
 
   return (
     <div
-      className={`fixed right-0 md:right-5 z-50 h-auto pr-2 md:pr-10 text-right hidden md:block ${
+      className={`fixed right-0 md:right-5 z-50 h-auto pr-2 md:pr-10 text-right hidden xl:block ${
         props.division !== 'education' ? 'top-1/3' : 'top-2/3'
       }`}
     >


### PR DESCRIPTION
I have implemented a visual style change for the carousels on each division page

The idea was to make the carousel look like the Figma components below:
<img width="598" height="929" alt="image" src="https://github.com/user-attachments/assets/34b16a62-eb40-418f-956e-7146606cbe6e" />

Because the current carousel component looks lame
<img width="982" height="488" alt="image" src="https://github.com/user-attachments/assets/7018a7ce-281b-445f-b23f-91767cb524fb" />

So here's what it looks like now:
<img width="974" height="555" alt="image" src="https://github.com/user-attachments/assets/f7cfd822-f576-4710-ab00-0a21d034ea2a" />

### Changes
#### New carousel design
- Removed the background of the carousel component, and created a border to wrap around the entire carousel component, which inherited the old background colors for each division
- Moved the image text to the bottom right with its own little floating modal
- Added autoscroll functionality

#### Lightbox modal
- Added a lightbox modal to display the image in its full size when clicked on
- Stops the autoscroller when the modal is open to prevent images changing while the modal is open
