### PR TITLE
feat(Events): Add time to the popup menu

### DIFF
--- a/src/components/Events/EventDays.tsx
+++ b/src/components/Events/EventDays.tsx
@@ -34,7 +34,6 @@ const EventComponent = ({ event, day, month }: Props) => {
   const formatDate = (date: Date) => {
     return date.toLocaleDateString('en-US', {
       weekday: 'long',
-      year: 'numeric',
       month: 'long',
       day: 'numeric',
     });
@@ -70,8 +69,17 @@ const EventComponent = ({ event, day, month }: Props) => {
         <div className="space-y-3 sm:space-y-4">
           {localStartDate && (
             <div className="space-y-1">
-              <h3 className="text-xs sm:text-sm md:text-base font-medium text-gray-200">Date</h3>
-              <p className="text-xs sm:text-sm md:text-base text-gray-100">{formatDate(localStartDate)}</p>
+              <h3 className="text-xs sm:text-sm md:text-base font-medium text-gray-200">Date & Time</h3>
+              <p className="text-xs sm:text-sm md:text-base text-gray-100">
+                {formatDate(localStartDate)}{" "}at{" "}
+                <span className="font-semibold">
+                  {localStartDate.toLocaleTimeString('en-US', {
+                    hour: 'numeric',
+                    minute: '2-digit',
+                    timeZoneName: 'short',
+                  })}
+                </span>
+              </p>
             </div>
           )}
           {event.location && (

--- a/src/components/Events/UpcomingEvents.tsx
+++ b/src/components/Events/UpcomingEvents.tsx
@@ -52,7 +52,6 @@ export default function UpcomingEvents() {
   const formatDate = (date: Date) => {
     return date.toLocaleDateString('en-US', {
       weekday: 'long',
-      year: 'numeric',
       month: 'long',
       day: 'numeric',
     });
@@ -96,8 +95,17 @@ export default function UpcomingEvents() {
               <div className="space-y-3 sm:space-y-4">
                 {event.start && (
                   <div className="space-y-1">
-                    <h3 className="text-xs sm:text-sm md:text-base font-medium text-gray-200">Date</h3>
-                    <p className="text-xs sm:text-sm md:text-base text-gray-100">{formatDate(event.start)}</p>
+                    <h3 className="text-xs sm:text-sm md:text-base font-medium text-gray-200">Date & Time</h3>
+                    <p className="text-xs sm:text-sm md:text-base text-gray-100">
+                      {formatDate(event.start)}{" "}at{" "}
+                      <span className="font-semibold">
+                        {event.start.toLocaleTimeString('en-US', {
+                          hour: 'numeric',
+                          minute: '2-digit',
+                          timeZoneName: 'short',
+                        })}
+                      </span>
+                    </p>
                   </div>
                 )}
                 {event.location && (


### PR DESCRIPTION
I added the time to display on the popup that appears when you click on an event on the events page

Old:
<img width="420" height="388" alt="image" src="https://github.com/user-attachments/assets/b48a0db3-b016-409f-9a26-992ac56313e3" />

New:
<img width="533" height="423" alt="image" src="https://github.com/user-attachments/assets/ff432dfc-678b-45bb-b199-22273f3386d0" />
